### PR TITLE
Add XMPP events

### DIFF
--- a/_posts/2014-09-10-xmpp-summit-16.md
+++ b/_posts/2014-09-10-xmpp-summit-16.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  "XMPP Summit 16"
+date:   2014-09-10
+venue: "MediaWiki Berlin"
+ticket: "Register at http://wiki.xmpp.org/web/Summit_16"
+time: "9:30am"
+href: "http://lanyrd.com/2014/xmpp/"
+---

--- a/_posts/2014-09-10-xmpp.js-hackathon.md
+++ b/_posts/2014-09-10-xmpp.js-hackathon.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  "xmpp.js hackathon"
+date:   2014-09-11
+venue: "MediaWiki, Berlin"
+ticket: "Open to all"
+time: "9:30am"
+href: "http://lanyrd.com/2014/xmpp-hackathon/"
+---


### PR DESCRIPTION
We're having two XMPP-based events in Berlin on the 10th and 11th of September.

The first is an XMPP core members meetup (open to all). The second event is a hackathon which is also open to all but more flexible and open including working with XMPP in javascript/nodejs.
