### PR TITLE
Fixed url for charity coding

### DIFF
--- a/_posts/2014-09-10-jsCharityCoding.md
+++ b/_posts/2014-09-10-jsCharityCoding.md
@@ -5,6 +5,6 @@ date:   2014-09-10
 venue: "Location: bitcrowd office"
 ticket: "RSVP"
 time: "10am - 6pm"
-href: "http://jsfest.berlin/charity_coding.html"
+href: "/charity_coding"
 ---
 <!-- fill in the URL of your event host page if you haven't enough information for a detail page, so the event link won't point on the detail page at all -->


### PR DESCRIPTION
…the old page was a manual created html file and because
of that had a different url :sob: . This is now the correct one.

Sorry for this.
